### PR TITLE
validate-user-email: BackEnd - Validate emails using regular expressions

### DIFF
--- a/todo-backend/src/main/java/com/umss/todo/controller/dto/UserCredentialsDto.java
+++ b/todo-backend/src/main/java/com/umss/todo/controller/dto/UserCredentialsDto.java
@@ -1,14 +1,14 @@
 package com.umss.todo.controller.dto;
 
-import javax.validation.constraints.Email;
+import com.umss.todo.validation.Email;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 public class UserCredentialsDto {
 	
 	@NotBlank(message = "Email field should not be null or empty.")
-	@Email(message = "Email field should be a valid email address.")
-//	@MyEmailValidator(message = "")
+	@Email(types = {"gmail", "hotmail", "umss"}, domains = {"com", "es", "edu.bo"})
 	private String email;
 	@Size
 	(

--- a/todo-backend/src/main/java/com/umss/todo/validation/Email.java
+++ b/todo-backend/src/main/java/com/umss/todo/validation/Email.java
@@ -1,0 +1,16 @@
+package com.umss.todo.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EmailValidation.class)
+public @interface Email {
+    String message() default "The field should be an email";
+    String[] domains() default {};
+    String[] types() default {};
+    Class<?>[] groups() default {};
+    public abstract Class<? extends Payload>[] payload() default {};
+}

--- a/todo-backend/src/main/java/com/umss/todo/validation/EmailValidation.java
+++ b/todo-backend/src/main/java/com/umss/todo/validation/EmailValidation.java
@@ -1,0 +1,38 @@
+package com.umss.todo.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EmailValidation implements ConstraintValidator<Email, String> {
+    private String regex = "^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@";
+    private String type = "(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+";
+    private String domain = "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value.matches(regex);
+    }
+
+    @Override
+    public void initialize(Email constraintAnnotation) {
+        String[] domains = constraintAnnotation.domains();
+        String[] types = constraintAnnotation.types();
+        if(types.length != 0) {
+            type = getRegex(types);
+        }
+        if(domains.length != 0) {
+            domain = "\\." + getRegex(domains) + "$";
+        }
+        regex += type + domain;
+    }
+
+    private String getRegex(final String[] regexps) {
+        String regularExp = "(";
+        for (String regexp: regexps) {
+            regularExp += regexp + "|";
+        }
+        regularExp = regularExp.substring(0, regularExp.length()-1);
+        regularExp += "){1}";
+        return regularExp;
+    }
+}


### PR DESCRIPTION
Validando correos electrónicos de los usuarios usando expresiones regulares. Se añadió funcionalidades, pudiendo pasar los **types** de correos electrónicos en un arreglo de `String`, como por ejemplo, correo electrónico de tipo `gmail`, de tipo `hotmail`, de tipo `umss`, etc. También se puede puede pasar **domains** en un arreglo de `String`, como por ejemplo dominios de correos electrónicos como: `com`, `es`, `edu.bo`, etc. Validando todos estos parámetros enviados con expresiones regulares, o dejándolo por defecto y validando por [Una implementación del Estandard Official: RFC 5322: ( valida en el 99.99% de los emails existentes )](http://w3.unpocodetodo.info/utiles/regex-ejemplos.php?type=email).